### PR TITLE
Improve replay viewer performance with GPU fallback and CPU limiting

### DIFF
--- a/openra_env/cli/main.py
+++ b/openra_env/cli/main.py
@@ -67,6 +67,26 @@ def main() -> None:
     watch_parser = replay_sub.add_parser("watch", help="Watch a replay in your browser (via VNC)")
     watch_parser.add_argument("file", nargs="?", default=None, help="Replay file (local path or container path; default: latest)")
     watch_parser.add_argument("--port", type=int, default=6080, help="noVNC port (default: 6080)")
+    watch_parser.add_argument(
+        "--resolution", default=None,
+        help="Replay viewer resolution WxH (default: 1280x960)",
+    )
+    watch_parser.add_argument(
+        "--render", dest="render_mode", choices=["auto", "gpu", "cpu"], default=None,
+        help="Render backend: auto tries GPU then CPU (default: auto)",
+    )
+    watch_parser.add_argument(
+        "--vnc-quality", type=int, default=None,
+        help="VNC quality 0-9, higher = sharper (default: 8)",
+    )
+    watch_parser.add_argument(
+        "--vnc-compression", type=int, default=None,
+        help="VNC compression 0-9, higher = smaller (default: 4)",
+    )
+    watch_parser.add_argument(
+        "--cpus", type=int, default=None,
+        help="CPU cores for software rendering (default: 4, 0 = all available).",
+    )
 
     replay_sub.add_parser("list", help="List available replays")
     replay_sub.add_parser("copy", help="Copy replays from Docker to ~/.openra-rl/replays/")
@@ -124,7 +144,15 @@ def main() -> None:
             server_parser.print_help()
     elif args.command == "replay":
         if args.replay_command == "watch":
-            commands.cmd_replay_watch(file=args.file, port=args.port)
+            commands.cmd_replay_watch(
+                file=args.file,
+                port=args.port,
+                resolution=args.resolution,
+                render_mode=args.render_mode,
+                vnc_quality=args.vnc_quality,
+                vnc_compression=args.vnc_compression,
+                cpu_cores=args.cpus,
+            )
         elif args.replay_command == "list":
             commands.cmd_replay_list()
         elif args.replay_command == "copy":


### PR DESCRIPTION
## Summary

- **GPU passthrough with auto-fallback**: Tries NVIDIA → WSL2 DXG → Linux DRI → CPU (software) automatically. Users can force `--render gpu` or `--render cpu`.
- **Docker CPU limiting for software rendering**: Caps container to 4 cores by default (`--cpus 4`), preventing Mesa llvmpipe from consuming all host CPU. Configurable via `--cpus N`.
- **Tunable replay viewer settings**: New CLI flags `--resolution`, `--render`, `--vnc-quality`, `--vnc-compression`, `--cpus` with env var fallbacks.
- **x11vnc optimizations**: `-noxdamage -wait 50 -defer 50` reduces VNC overhead.
- **OpenRA graphics tuning**: VSync=False, DisableGLDebugMessageCallback, Windowed mode, Sound.Mute passed via env vars from Python to the shell script.
- **Health-check polling**: Replaces `sleep(3)` with a 30s polling loop that detects early container exit and shows logs on failure.
- **Stale container cleanup**: Automatically removes exited replay containers before starting a new one.

### Performance (macOS Docker Desktop, no GPU)

| Before | After (default) |
|--------|-----------------|
| ~1300% CPU (all cores) | ~400% CPU (4 cores) |
| Same visual quality | Same visual quality |

## Test plan

- [x] `pytest tests/test_cli.py` — 71 tests pass (18 new)
- [x] `pytest tests/` — 435 tests pass
- [x] E2E: `openra-rl replay watch` with default settings (4 cores, ~400% CPU)
- [x] E2E: Tested with `--cpus 2`, `--cpus 14` (all cores) — confirmed CPU scaling
- [x] Stale container cleanup works (start → kill → start again)
- [x] Health polling detects ready state correctly
- [x] GPU fallback chain degrades gracefully on macOS (no GPU → CPU)

Closes #5