### PR TITLE
Fix UnicodeDecodeError on Windows with Chinese locale

### DIFF
--- a/examples/llm_agent.py
+++ b/examples/llm_agent.py
@@ -127,7 +127,7 @@ def main():
     if config.agent.log_file:
         import builtins
         _builtin_print = builtins.print
-        _log_fh = open(config.agent.log_file, "w")
+        _log_fh = open(config.agent.log_file, "w", encoding="utf-8")
 
         def _tee_print(*pargs, **kwargs):
             _builtin_print(*pargs, **kwargs)

--- a/openra_env/cli/docker_manager.py
+++ b/openra_env/cli/docker_manager.py
@@ -27,6 +27,7 @@ def _run(args: list[str], capture: bool = True, **kwargs) -> subprocess.Complete
         args,
         capture_output=capture,
         text=True,
+        encoding="utf-8",
         **kwargs,
     )
 
@@ -114,7 +115,7 @@ def _load_manifest() -> dict:
     """Load the replay manifest (replay filename → image tag)."""
     if MANIFEST_PATH.exists():
         try:
-            return json.loads(MANIFEST_PATH.read_text())
+            return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
     return {}
@@ -123,7 +124,7 @@ def _load_manifest() -> dict:
 def _save_manifest(manifest: dict) -> None:
     """Save the replay manifest."""
     MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
-    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n")
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
 
 def get_replay_image_tag(replay_filename: str) -> Optional[str]:

--- a/openra_env/cli/wizard.py
+++ b/openra_env/cli/wizard.py
@@ -90,7 +90,7 @@ def load_saved_config() -> Optional[dict]:
     if not CONFIG_PATH.exists():
         return None
     try:
-        with open(CONFIG_PATH) as f:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     except Exception:
         return None
@@ -99,7 +99,7 @@ def load_saved_config() -> Optional[dict]:
 def save_config(config: dict) -> None:
     """Save config to ~/.openra-rl/config.yaml."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_PATH, "w") as f:
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
     success(f"Config saved to {CONFIG_PATH}")
 

--- a/openra_env/config.py
+++ b/openra_env/config.py
@@ -308,7 +308,7 @@ def load_config(
     # 1. Load YAML file
     resolved_path = _resolve_config_path(config_path)
     if resolved_path is not None:
-        with open(resolved_path) as f:
+        with open(resolved_path, encoding="utf-8") as f:
             file_dict = yaml.safe_load(f) or {}
         _deep_merge(config_dict, file_dict)
 


### PR DESCRIPTION
## Summary

- Add `encoding="utf-8"` to all file I/O and subprocess calls that were missing it
- Fixes `UnicodeDecodeError: 'gbk' codec can't decode byte...` on Windows with Chinese locale

Python defaults to the system locale encoding (GBK for Chinese Windows) for `open()`, `Path.read_text()`, and `subprocess.run(text=True)`. Without explicit `encoding="utf-8"`, all these calls fail when Docker output or config files contain non-ASCII bytes.

**7 locations fixed:**
| File | Function |
|------|----------|
| `openra_env/cli/docker_manager.py` | `_run()` — all Docker subprocess calls |
| `openra_env/cli/docker_manager.py` | `_load_manifest()` — replay manifest read |
| `openra_env/cli/docker_manager.py` | `_save_manifest()` — replay manifest write |
| `openra_env/cli/wizard.py` | `load_saved_config()` — config YAML read |
| `openra_env/cli/wizard.py` | `save_config()` — config YAML write |
| `openra_env/config.py` | `load_config()` — central config loader |
| `examples/llm_agent.py` | `main()` — log file write |

## Test plan

- [x] `pytest tests/` — 435 tests pass (no-op on UTF-8 locales like macOS/Linux)