### PR TITLE
Fix wizard default model and improve CLI error messages

### DIFF
--- a/openra_env/cli/commands.py
+++ b/openra_env/cli/commands.py
@@ -128,9 +128,12 @@ def cmd_play(
     except KeyboardInterrupt:
         print("\nInterrupted.")
     except ConnectionRefusedError:
-        error(f"Could not connect to {actual_url}. Is the server running?")
+        error(f"Could not connect to {actual_url}.")
+        info("Try: openra-rl server start")
+        info("Check: openra-rl doctor")
     except Exception as e:
         error(f"Agent error: {e}")
+        info("Run with --verbose for full details, or check: openra-rl doctor")
 
     # 5. Auto-copy replays from Docker
     if use_docker and docker.is_running():

--- a/openra_env/cli/wizard.py
+++ b/openra_env/cli/wizard.py
@@ -17,21 +17,13 @@ PROVIDERS = {
         "base_url": "https://openrouter.ai/api/v1/chat/completions",
         "needs_key": True,
         "key_help": "Get one at https://openrouter.ai/keys",
-        "default_model": "anthropic/claude-sonnet-4-20250514",
-        "models": [
-            ("anthropic/claude-sonnet-4-20250514", "Claude Sonnet 4 (recommended)"),
-            ("qwen/qwen3-coder-next", "Qwen3 Coder (budget)"),
-        ],
+        "default_model": "qwen/qwen3-coder-next",
     },
     "ollama": {
         "name": "Ollama",
         "base_url": "http://localhost:11434/v1/chat/completions",
         "needs_key": False,
         "default_model": "qwen3:32b",
-        "models": [
-            ("qwen3:32b", "Qwen3 32B (recommended)"),
-            ("qwen3:4b", "Qwen3 4B (lightweight)"),
-        ],
     },
     "lmstudio": {
         "name": "LM Studio",

--- a/openra_env/mcp_ws_client.py
+++ b/openra_env/mcp_ws_client.py
@@ -77,6 +77,11 @@ class OpenRAMCPClient:
                 max_size=50 * 1024 * 1024,  # 50 MB
                 ping_interval=None,
             )
+        except (asyncio.TimeoutError, OSError, ConnectionRefusedError) as e:
+            raise RuntimeError(
+                f"Could not connect to game server at {self._ws_url}: {e}\n"
+                f"  Is the server running? Try: openra-rl server start"
+            ) from e
         finally:
             if is_localhost:
                 if old_no_proxy is None:


### PR DESCRIPTION
## Summary
- Fix OpenRouter wizard default model from stale `anthropic/claude-sonnet-4-20250514` to `qwen/qwen3-coder-next`
- Remove hardcoded model lists from OpenRouter and Ollama wizard presets — users now get a simple "Enter model ID [default]:" prompt
- Add status-specific LLM error messages: 401/403 → check API key, 400+model → invalid model ID, 429 → rate limited
- Show error detail in planning phase API failures instead of generic message
- Add `--verbose` and `openra-rl doctor` hints to CLI catch-all error messages
- Wrap WebSocket connection failures with actionable "Is the server running?" guidance

## Test plan
- [x] All 435 tests pass
- [x] Verify wizard shows `Enter model ID [qwen/qwen3-coder-next]:` for OpenRouter
- [x] Verify auth errors show "Check your API key: openra-rl config"
- [x] Verify connection errors suggest `openra-rl server start` and `openra-rl doctor`