### PR TITLE
Add AMD GPU support for replay viewer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1-mesa-dri \
     libgl1-mesa-glx \
     libegl-mesa0 \
+    mesa-vulkan-drivers \
+    libvulkan1 \
     libsdl2-2.0-0 \
     libopenal1 \
     libfreetype6 \

--- a/docker/replay-viewer.sh
+++ b/docker/replay-viewer.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# The base image sets LIBGL_ALWAYS_SOFTWARE=1 for the headless game server.
+# The replay viewer needs GPU rendering, so unset it.
+unset LIBGL_ALWAYS_SOFTWARE
+
 REPLAY_FILE="$1"
 if [ -z "$REPLAY_FILE" ]; then
     echo "Usage: /replay-viewer.sh <replay_file_path>"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -216,14 +216,16 @@ class TestReplayViewerSettings:
     def test_gpu_docker_args_gpu(self):
         from openra_env.cli.docker_manager import _gpu_docker_args
         variants = _gpu_docker_args("gpu")
-        assert len(variants) == 3
+        assert len(variants) == 4  # NVIDIA, WSL2, AMD ROCm, DRI
         assert "--gpus" in variants[0]
-        assert "--device" in variants[1]
+        assert "/dev/dxg" in str(variants[1])
+        assert "/dev/kfd" in str(variants[2])
+        assert "/dev/dri" in str(variants[3])
 
     def test_gpu_docker_args_auto(self):
         from openra_env.cli.docker_manager import _gpu_docker_args
         variants = _gpu_docker_args("auto")
-        assert len(variants) == 4
+        assert len(variants) == 5  # 4 GPU + 1 CPU
         # GPU variants first, CPU last
         assert "--gpus" in variants[0]
         assert "LIBGL_ALWAYS_SOFTWARE=1" in variants[-1]


### PR DESCRIPTION
## Summary
- Fix replay viewer being forced into slow software rendering even with GPU passthrough
- Add proper AMD GPU support (WSL2 DirectX, ROCm, DRI)
- Show specific GPU type in CLI output

## Root Cause
`LIBGL_ALWAYS_SOFTWARE=1` was baked into the Dockerfile for the headless game server but leaked into the replay viewer container, forcing Mesa llvmpipe (CPU) rendering regardless of GPU passthrough.

## Changes
- **`docker/replay-viewer.sh`**: `unset LIBGL_ALWAYS_SOFTWARE` at script start — primary fix
- **`docker_manager.py`**: Enhanced GPU variants:
  - NVIDIA: `--gpus all` (unchanged)
  - WSL2: `--device /dev/dxg` + `-v /usr/lib/wsl:/usr/lib/wsl:ro` + `LD_LIBRARY_PATH` (AMD/NVIDIA/Intel on Windows)
  - AMD ROCm: `--device /dev/kfd` + `--device /dev/dri` + `--group-add video` (native Linux AMD)
  - Generic DRI: `--device /dev/dri` (fallback for AMD/Intel Mesa)
- **`Dockerfile`**: Added `mesa-vulkan-drivers` and `libvulkan1` for D3D12/Vulkan driver support
- **CLI output**: Now shows "GPU (NVIDIA)", "GPU (WSL2 DirectX)", "GPU (AMD ROCm)", or "GPU (DRI)" instead of generic "GPU (hardware acceleration)"

## Test plan
- [x] All 435 tests pass
- [ ] AMD GPU on Windows (WSL2): replay viewer uses GPU instead of CPU
- [ ] NVIDIA: no regression, still works with `--gpus all`
- [ ] CPU fallback still works when no GPU available