### PR TITLE
Agent system improvements: compression, ETA, bot spawning, defense placement

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,9 +19,11 @@ game:
 #   max_wall_time_s: 0                # End game after N seconds (0 = unlimited)
 
 # ── Opponent ──────────────────────────────────────────────────────────
+# Enemy bot always spawns by default. Set ai_slot to "" to disable.
+# bot_type accepts friendly names (easy/normal/hard) or OpenRA names (rush/normal/turtle/naval).
 opponent:
-  bot_type: "easy"                    # AI difficulty: easy, normal, hard ($BOT_TYPE)
-  ai_slot: "Multi0"                   # AI player slot ($AI_SLOT)
+  bot_type: "easy"                    # easy=rush, normal=normal, hard=turtle ($BOT_TYPE)
+  ai_slot: "Multi0"                   # AI player slot; "" to disable enemy ($AI_SLOT)
 
 # ── Planning Phase ────────────────────────────────────────────────────
 # planning:
@@ -71,6 +73,7 @@ opponent:
 #   no_defenses: true
 #   no_scouting: true
 #   loss_tracking: true
+#   max_alerts: 0                    # Max alerts per turn (0 = unlimited)
 
 # ── LLM Model ────────────────────────────────────────────────────────
 # llm:
@@ -80,7 +83,9 @@ opponent:
 #   max_tokens: 1500
 #   temperature: null                 # null = provider default
 #   top_p: null                       # null = provider default
-#   keep_last_messages: 40            # History compression window
+#   keep_last_messages: 40            # Messages to keep after compression
+#   compression_strategy: "sliding_window"  # "sliding_window" or "none"
+#   compression_trigger: 0            # Compress at this count (0 = keep_last * 2)
 #   max_retries: 4                    # Retry on transient errors
 #   retry_backoff_s: 10               # Base backoff (multiplied by attempt)
 #   request_timeout_s: 120.0          # HTTP timeout per request
@@ -95,3 +100,20 @@ opponent:
 #   max_time_s: 1800                  # 30 minutes ($MAX_TIME)
 #   verbose: false
 #   log_file: ""                      # Log file path ($LLM_AGENT_LOG)
+
+# ── Prompts ──────────────────────────────────────────────────────────
+# All LLM-facing text. Override individual fields here, or point
+# prompts_file to a separate YAML (copy openra_env/prompts/default_prompts.yaml).
+# Templates use Python str.format() placeholders: {variable_name}
+# prompts:
+#   system_prompt: ""                 # Inline system prompt (overrides built-in)
+#   system_prompt_file: ""            # Path to .txt system prompt ($SYSTEM_PROMPT_FILE)
+#   prompts_file: ""                  # Path to prompts YAML ($PROMPTS_FILE)
+#   planning_nudge: "Call end_planning_phase(strategy='...') when ready to start."
+#   planning_complete: "Planning complete. Game is now live."
+#   no_tool_nudge: "No tool was called. A tool call is required each turn."
+#   continue_nudge: "The game is still in progress."
+#   alerts:                           # Alert message templates
+#     low_power: "LOW POWER: {balance} — production runs at 1/3 speed"
+#     idle_army: "IDLE ARMY: {count} combat units idle"
+#     # ... see openra_env/prompts/default_prompts.yaml for all fields

--- a/examples/llm_agent.py
+++ b/examples/llm_agent.py
@@ -29,6 +29,7 @@ from openra_env.agent import run_agent
 # Re-export for backwards compatibility
 from openra_env.agent import (  # noqa: F401
     SYSTEM_PROMPT,
+    load_system_prompt,
     compose_pregame_briefing,
     format_state_briefing,
     mcp_tools_to_openai,
@@ -99,6 +100,11 @@ def main():
         default=None,
         help="Write all output to this log file in addition to stdout",
     )
+    parser.add_argument(
+        "--system-prompt",
+        default=None,
+        help="Path to a custom system prompt .txt file (overrides built-in default)",
+    )
     args = parser.parse_args()
 
     # Build config: YAML file + env vars + CLI overrides (CLI wins over .env)
@@ -119,6 +125,8 @@ def main():
         cli.setdefault("agent", {})["verbose"] = True
     if args.log_file is not None:
         cli.setdefault("agent", {})["log_file"] = args.log_file
+    if args.system_prompt is not None:
+        cli.setdefault("agent", {})["system_prompt_file"] = args.system_prompt
 
     config = load_config(config_path=args.config, cli_overrides=cli)
     verbose = config.agent.verbose

--- a/openra_env/prompts/__init__.py
+++ b/openra_env/prompts/__init__.py
@@ -1,0 +1,32 @@
+"""Default prompts and prompt loading for OpenRA-RL agents."""
+
+from pathlib import Path
+
+import yaml
+
+_PROMPTS_DIR = Path(__file__).parent
+
+
+def load_default_prompt() -> str:
+    """Load the default system prompt shipped with the package."""
+    return (_PROMPTS_DIR / "default.txt").read_text(encoding="utf-8").strip()
+
+
+def load_default_prompts_yaml() -> dict:
+    """Load the default prompts YAML shipped with the package."""
+    path = _PROMPTS_DIR / "default_prompts.yaml"
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_prompts_file(prompts_file: str) -> dict:
+    """Load a custom prompts YAML file.
+
+    Returns a dict suitable for merging into PromptsConfig fields.
+    Raises FileNotFoundError if the file doesn't exist.
+    """
+    p = Path(prompts_file).expanduser()
+    if not p.is_file():
+        raise FileNotFoundError(f"prompts_file not found: {p}")
+    with open(p, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}

--- a/openra_env/prompts/default.txt
+++ b/openra_env/prompts/default.txt
@@ -1,0 +1,67 @@
+You are playing Command & Conquer: Red Alert as one faction against an AI opponent.
+
+## Interface
+
+The game runs in real time at ~25 ticks/sec. You interact through tool calls. Between your turns, a TURN BRIEFING shows current state: economy, units, buildings, enemies, production queue, and available builds. A STRATEGIC BRIEFING at game start provides map size, base position, enemy spawn estimate, faction, tech tree, and unit/building stats.
+
+## Economy
+
+Funds = cash + ore. Harvesters collect ore from patches and deliver it to refineries. Each ore refinery (proc, $2000) comes with one free harvester. Silos ($150) add +1500 ore storage capacity. Construction costs are paid incrementally — if funds reach $0, all production pauses until income resumes.
+
+## Power
+
+Power plants (powr, $300) provide +100 power each. When power demand exceeds supply, all production runs at 1/3 speed. Each building has a power drain listed in its stats.
+
+## Production
+
+- Barracks (tent/barr, $400): trains infantry (e1 rifleman $100, e2 grenadier $160, e3 rocket soldier $300, e6 engineer $500)
+- War factory (weap, $2000): builds vehicles (light tank 1tnk $600, medium tank 2tnk $800, heavy tank 3tnk $950, APC $800, harvester $1400)
+- Multiple production buildings of the same type increase build speed
+
+## Tech Tree
+
+Buildings have prerequisites. Standard unlock chain: powr → barracks → proc → weap. A war factory requires an ore refinery. The "Can build:" line in each briefing shows what is currently available.
+
+## Combat
+
+Vehicles are much stronger than infantry. A heavy tank (3tnk, $950) defeats ~10 riflemen (e1, $100 each). Rocket soldiers (e3) are effective against vehicles and aircraft. Engineers (e6) can capture enemy buildings.
+
+## Defense Structures
+
+Defense turrets are stationary and engage enemies automatically.
+
+Allied:
+- Pillbox (pbox, $400, no power drain, needs barracks) — anti-infantry
+- Camo Pillbox (hbox, $600, no power drain, needs barracks) — hidden anti-infantry
+- Gun Turret (gun, $600, -20 power, needs war factory) — anti-armor
+
+Soviet:
+- Flame Tower (ftur, $600, -20 power, needs barracks) — anti-infantry
+- Tesla Coil (tsla, $1500, -75 power, needs war factory) — high damage, all targets
+
+Anti-air:
+- SAM Site (sam, Soviet, $750, needs radar dome)
+- AA Gun (agun, Allied, $600, needs radar dome)
+- Rocket soldiers (e3) provide mobile anti-air
+
+## Map & Fog of War
+
+The map is partially hidden by fog of war. Units reveal terrain as they move. Exploration status (overall %, per-quadrant) is available via tools. Enemy positions are only visible when within your units' sight range.
+
+## Rally Points
+
+Production buildings can have rally points set. Newly produced units automatically move to the rally point location.
+
+## Planning Phase
+
+If planning is enabled, a planning phase occurs before gameplay. It provides map metadata, faction info, and an opponent intelligence report with behavioral tendencies and difficulty assessment. Use bulk knowledge tools (get_faction_briefing, get_map_analysis) to gather information efficiently.
+
+## Briefing Format
+
+Each turn briefing includes:
+- Funds (cash + ore), power balance, harvester count
+- Your units with IDs, types, and positions
+- Your buildings with IDs, types, and positions
+- Visible enemies with IDs, types, and positions
+- Current production queue and available builds
+- ALERTS for events needing attention (attacks, low power, idle production, etc.)

--- a/openra_env/prompts/default_prompts.yaml
+++ b/openra_env/prompts/default_prompts.yaml
@@ -1,0 +1,144 @@
+# OpenRA-RL Default Prompts
+# =========================
+# All LLM-facing text used by the agent. Copy this file and customize
+# to change what the model sees. Point to your copy via:
+#   prompts:
+#     prompts_file: "path/to/my_prompts.yaml"
+# in config.yaml, or set PROMPTS_FILE environment variable.
+#
+# Templates use Python str.format() placeholders: {variable_name}
+# Available variables are documented in comments above each template.
+
+# ── Planning Phase ───────────────────────────────────────────────────
+
+# Variables: {max_turns}, {map_name}, {map_width}, {map_height},
+#   {base_x}, {base_y}, {enemy_x}, {enemy_y}, {faction}, {side},
+#   {opponent_summary}, {planning_nudge}
+planning_prompt: |
+  ## PRE-GAME PLANNING PHASE
+  You have {max_turns} turns to plan.
+
+  ### Map Intel
+  Map: {map_name} ({map_width}x{map_height})
+  Your base: ({base_x}, {base_y})
+  Enemy estimated: ({enemy_x}, {enemy_y})
+  Your faction: {faction} ({side})
+
+  ### Opponent Intelligence
+  {opponent_summary}
+
+  {planning_nudge}
+
+planning_nudge: "Call end_planning_phase(strategy='...') when ready to start."
+
+planning_instructions: >-
+  Planning phase active. Available tools: get_faction_briefing
+  (all unit/building stats), get_map_analysis (terrain/resources),
+  get_opponent_intel (enemy profile), batch_lookup (multi-item queries).
+  Call end_planning_phase(strategy=...) to begin gameplay.
+
+planning_complete: "Planning complete. Game is now live."
+
+# ── Game Start ───────────────────────────────────────────────────────
+
+# Variables: {strategy_section}, {briefing}, {barracks_type}, {mcv_note}
+game_start: "Game started!{strategy_section}\n\n{briefing}\n\nYour barracks type is '{barracks_type}'.{mcv_note}"
+
+# ── Agent Nudges ─────────────────────────────────────────────────────
+
+no_tool_nudge: "No tool was called. A tool call is required each turn."
+continue_nudge: "The game is still in progress."
+compression_suffix: "Game continues from current state."
+sanitize_bridge: "Acknowledged. Continuing."
+
+# ── Tool Warnings ────────────────────────────────────────────────────
+
+# Variables: {building}, {drain}, {balance}
+power_warning: "POWER WARNING: {building} drains {drain} power. Balance will be {balance}."
+
+# Variables: {available}, {item}, {cost}
+insufficient_funds: "Insufficient funds: ${available} available, {item} costs ${cost}."
+
+# ── Placement Feedback ───────────────────────────────────────────────
+
+# Variables: {building}
+placement_success: "AUTO-PLACED: {building}"
+
+# Variables: {building}, {reason}
+placement_failed: "PLACEMENT FAILED: {building} — {reason}. Auto-cancelling."
+
+# Variables: {building}
+placement_water: "WATER BUILDING: {building} requires water tiles for placement."
+
+# ── Build Confirmations ─────────────────────────────────────────
+# Factual confirmation notes returned by build tools.
+
+# Variables: {building}, {cost}, {ticks}, {seconds}
+build_queued: "'{building}' (${cost}) queued, auto-places on completion. ~{ticks} ticks (~{seconds}s)."
+
+# Variables: {building}, {cost}, {ticks}, {seconds}
+build_structure_queued: "'{building}' (${cost}) queued. ~{ticks} ticks (~{seconds}s) to complete."
+
+# Variables: {count}, {unit}, {cost}, {ticks_each}, {ticks_total}, {seconds_total}
+build_unit_queued: "{count}x '{unit}' (${cost} each) queued. ~{ticks_each} ticks per unit, ~{ticks_total} ticks (~{seconds_total}s) total."
+
+# ── Build Guards ────────────────────────────────────────────────
+
+# Variables: {building}
+build_already_pending: "'{building}' is already queued and pending auto-placement."
+
+# Variables: {building}
+place_auto_managed: "'{building}' is queued via build_and_place — placement is automatic."
+
+# ── Movement Feedback ───────────────────────────────────────────────
+
+# Variables: {ticks}, {seconds}
+move_eta: "Units moving. Slowest arrives in ~{ticks} ticks (~{seconds}s)."
+
+# ── Alerts ───────────────────────────────────────────────────────────
+# These appear in the TURN BRIEFING under ALERTS.
+# Each alert type can be enabled/disabled separately in the alerts config.
+
+alerts:
+  # Variables: {type}, {id}
+  under_attack: "UNDER ATTACK: enemy {type} id={id} near base"
+
+  # Variables: {count}, {breakdown}
+  under_attack_mass: "UNDER ATTACK: {count} enemies near base ({breakdown})"
+
+  # Variables: {type}, {id}, {hp}
+  damaged: "DAMAGED: {type} id={id} at {hp} HP"
+
+  # Variables: {balance}
+  low_power: "LOW POWER: {balance} — production runs at 1/3 speed"
+
+  # Variables: {balance}
+  power_tight: "POWER TIGHT: {balance} surplus — next building may cause low power"
+
+  # Variables: {funds}, {harvesters}
+  idle_funds: "IDLE FUNDS: ${funds} available, {harvesters} harvester(s)"
+
+  # Variables: {ore}, {cap}
+  ore_full: "ORE FULL: {ore}/{cap} storage — income is being lost"
+
+  idle_production: "IDLE PRODUCTION: no active production queue"
+
+  # Variables: {item}, {progress}
+  stalled: "STALLED: {item}@{progress} — $0 funds, production paused"
+
+  # Variables: {building}
+  building_stuck: "BUILDING STUCK: {building} — auto-placement failing"
+
+  # Variables: {building}
+  ready_to_place: "READY TO PLACE: {building} — completed, awaiting placement"
+
+  # Variables: {count}
+  stance: "STANCE: {count} combat unit(s) on ReturnFire (only fire when fired upon)"
+
+  # Variables: {count}
+  idle_army: "IDLE ARMY: {count} combat units idle"
+
+  no_defenses: "NO DEFENSES: no defense structures built"
+
+  # Variables: {explored}, {idle}
+  no_scouting: "NO SCOUTING: enemy not found — {explored} of map explored, {idle} idle combat units available"

--- a/openra_env/server/openra_process.py
+++ b/openra_env/server/openra_process.py
@@ -16,6 +16,15 @@ logger = logging.getLogger(__name__)
 # Default path to the OpenRA installation
 DEFAULT_OPENRA_PATH = os.environ.get("OPENRA_PATH", "/opt/openra")
 
+# Map user-friendly difficulty names to actual OpenRA bot type strings.
+# Users can set either the friendly name or the raw OpenRA name.
+BOT_TYPE_MAP: dict[str, str] = {
+    "easy": "rush",
+    "normal": "normal",
+    "hard": "turtle",
+}
+
+
 
 @dataclass
 class OpenRAConfig:
@@ -28,7 +37,7 @@ class OpenRAConfig:
     bot_name: str = "Normal AI"
     bot_type: str = "normal"
     rl_slot: str = "Multi1"
-    ai_slot: str = ""
+    ai_slot: str = "Multi0"
     seed: Optional[int] = None
     headless: bool = True  # Use Null renderer (no GPU needed)
     record_replays: bool = False  # Enable .orarep replay recording
@@ -104,7 +113,9 @@ class OpenRAProcessManager:
         # Build bots configuration: slot:bottype,slot:bottype
         bots = f"{self.config.rl_slot}:rl-agent"
         if self.config.ai_slot:
-            bots += f",{self.config.ai_slot}:{self.config.bot_type}"
+            # Map friendly names (easy/normal/hard) to OpenRA types (rush/normal/turtle)
+            actual_type = BOT_TYPE_MAP.get(self.config.bot_type, self.config.bot_type)
+            bots += f",{self.config.ai_slot}:{actual_type}"
 
         args = [
             *exe,


### PR DESCRIPTION
## Summary
- **Configurable history compression**: separate trigger threshold from window size, `"none"` strategy to disable, `CompressionConfig` controls what context preserved in summaries (strategy, military, production)
- **Movement ETA**: `move_units`/`attack_move` return estimated arrival ticks per unit; turn briefing shows unit activity and destination (`→(x,y)` for tracked targets, `→mov`/`→att` for activity)
- **Fix enemy bot not spawning**: map friendly names (`easy`/`normal`/`hard`) to actual OpenRA bot types (`rush`/`normal`/`turtle`); default `ai_slot="Multi0"` so enemies always spawn
- **Defense placement bias**: turrets/pillboxes placed toward enemy direction (using visible enemies or map geometry) instead of behind the base
- **Build confirmation notes** with tick/second estimates on all build tools
- **Pending-placement guards** prevent double-ordering builds or manually placing auto-managed buildings
- **Alert priority system** (1=under_attack → 7=idle) with configurable `max_alerts` cap
- **Unknown tool suggestions** via `difflib.get_close_matches` when LLM hallucinates tool names
- **Prompts system**: externalized default system prompt and prompt templates to `openra_env/prompts/`
- **MCP server docstrings** improved for build/place/advance tool clarity

## Test plan
- [x] 522 tests pass (43 new) covering compression config, movement ETA, bot type mapping, defense placement bias, build notes, pending guards, alert priority, state briefing format
- [x] Live game verified: Rush AI spawns and attacks, compression cycles correctly (30→38→30), ETAs display in tool results, build notes show tick estimates
- [x] Config round-trips through YAML loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)