### PR TITLE
Fix tool-capability detection false positives and always export bench JSON locally

### DIFF
--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -195,14 +195,16 @@ class TestToolCallingPreflight:
 class TestBenchExportPolicy:
     """Tests for when bench export/upload is allowed."""
 
-    def test_skip_export_when_runtime_error_occurred(self):
-        should_export, reason = _bench_export_policy(encountered_agent_error=True)
-        assert should_export is False
+    def test_always_exports_locally_even_on_error(self):
+        should_export, should_upload, reason = _bench_export_policy(encountered_agent_error=True)
+        assert should_export is True
+        assert should_upload is False
         assert "runtime [error]" in reason.lower()
 
-    def test_allow_export_when_no_runtime_error(self):
-        should_export, reason = _bench_export_policy(encountered_agent_error=False)
+    def test_allow_export_and_upload_when_no_runtime_error(self):
+        should_export, should_upload, reason = _bench_export_policy(encountered_agent_error=False)
         assert should_export is True
+        assert should_upload is True
         assert reason == ""
 
 


### PR DESCRIPTION
## Summary
- Remove generic markers (`"no endpoints found"`, `"unsupported parameter"`) from `_looks_like_tool_capability_error()` to avoid misclassifying unrelated 404s. The guarded check requiring both `"no endpoints found"` AND `"tool"` already handles the OpenRouter case correctly.
- Change `_bench_export_policy()` to a 3-tuple `(should_export, should_upload, reason)`. Local bench JSON is always written (useful for debugging), only the leaderboard upload is skipped when runtime errors occurred.
- Update tests to match new return shape and semantics.

Based on review feedback from #25.

## Test plan
- [x] All 594 tests pass
- [x] `test_llm_agent.py` — 17 tests covering error formatting, preflight, and bench export policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)