### PR TITLE
Add hf_token support for verified bench submissions

### DIFF
--- a/openra_env/agent.py
+++ b/openra_env/agent.py
@@ -1130,6 +1130,10 @@ async def run_agent(config, verbose: bool = False):
                 "replay_path": replay.get("path", ""),
                 "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
+            # Include HF token for verified bench submissions (not saved locally)
+            hf_token = config.agent.hf_token
+            if hf_token:
+                sub["hf_token"] = hf_token
             export_dir = Path.home() / ".openra-rl" / "bench-exports"
             export_dir.mkdir(parents=True, exist_ok=True)
             ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")

--- a/openra_env/bench_export.py
+++ b/openra_env/bench_export.py
@@ -33,6 +33,7 @@ def build_bench_export(
     opponent: str = "Normal",
     agent_url: str = "",
     replay_path: str = "",
+    hf_token: str = "",
     export_dir: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Build and save a bench export JSON from a final observation.
@@ -45,6 +46,7 @@ def build_bench_export(
         opponent: Difficulty tier (Beginner/Easy/Medium/Normal/Hard).
         agent_url: Optional GitHub/project URL.
         replay_path: Optional path to .orarep replay file.
+        hf_token: Optional HuggingFace token for verified bench submissions.
         export_dir: Where to save the JSON (default: ~/.openra-rl/bench-exports/).
 
     Returns:
@@ -80,6 +82,8 @@ def build_bench_export(
         "replay_path": replay_path,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    if hf_token:
+        sub["hf_token"] = hf_token
 
     # Save to disk
     if export_dir is None:

--- a/openra_env/bench_submit.py
+++ b/openra_env/bench_submit.py
@@ -123,6 +123,7 @@ def main() -> None:
     parser.add_argument("--agent-name", default=None, help="Override agent name in the submission")
     parser.add_argument("--agent-type", default=None, help="Override agent type (Scripted/LLM/RL)")
     parser.add_argument("--agent-url", default=None, help="GitHub/project URL for the agent")
+    parser.add_argument("--hf-token", default=None, help="HuggingFace token for verified submissions")
     parser.add_argument("--replay", default=None, help="Path to .orarep replay file")
     parser.add_argument(
         "--bench-url",
@@ -148,6 +149,8 @@ def main() -> None:
         data["agent_type"] = args.agent_type
     if args.agent_url:
         data["agent_url"] = args.agent_url
+    if args.hf_token:
+        data["hf_token"] = args.hf_token
 
     print(f"Submitting {data.get('agent_name', '?')} vs {data.get('opponent', '?')}...")
     print(f"  Bench: {args.bench_url}")

--- a/openra_env/config.py
+++ b/openra_env/config.py
@@ -150,6 +150,7 @@ class AgentConfig(BaseModel):
     agent_url: str = ""  # GitHub/project URL shown on leaderboard
     bench_upload: bool = True  # Auto-upload results to bench after each game
     bench_url: str = "https://openra-rl-openra-bench.hf.space"
+    hf_token: str = ""  # HuggingFace token for verified bench submissions
     system_prompt: str = ""  # deprecated — use prompts.system_prompt
     system_prompt_file: str = ""  # deprecated — use prompts.system_prompt_file
 
@@ -413,6 +414,7 @@ _ENV_VAR_MAP: list[tuple[str, str]] = [
     ("AGENT_URL", "agent.agent_url"),
     ("BENCH_UPLOAD", "agent.bench_upload"),
     ("BENCH_URL", "agent.bench_url"),
+    ("HF_TOKEN", "agent.hf_token"),
     ("SYSTEM_PROMPT_FILE", "agent.system_prompt_file"),
     # prompts
     ("SYSTEM_PROMPT_FILE", "prompts.system_prompt_file"),  # also maps to prompts.*


### PR DESCRIPTION
- Add hf_token field to AgentConfig with HF_TOKEN env var mapping
- Include hf_token in auto-upload submissions (agent.py)
- Add --hf-token CLI arg to bench_submit.py
- Add hf_token parameter to build_bench_export()
- Token is sent to bench server for verification, not stored locally