### PR TITLE
fix MCP Bot tool call errors

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,3 +48,72 @@ Step  200 | Tick   200 | $ 4100 | Units: 1 (combat: 0) | Buildings: [fact, powr]
 Game over: win after 3421 steps (tick 3421)
 Total reward: 2.150
 ```
+
+---
+
+## MCP Bot
+
+A hardcoded Red Alert bot that plays a full game through MCP tool calls (the same interface available to LLM agents).
+
+**Strategy:** Look up tech tree & faction info → Deploy MCV → Build Power Plant → Build Barracks → Build Refinery → Build War Factory → Train infantry + vehicles → Attack-move toward enemy with sustain management.
+
+### Prerequisites
+
+Uncomment the following two lines in your `config.yaml` to enable all MCP tools this bot uses:
+
+```yaml
+# ── MCP Tools ─────────────────────────────────────────────────────────
+tools:
+  disabled: []
+```
+
+Then restart the server so the config takes effect.
+
+```bash
+# Start the OpenRA-RL server (Docker)
+docker run -p 8000:8000 openra-rl
+
+# Or from local:
+python openra_env/server/app.py
+```
+
+### Run
+
+```bash
+# Basic run
+python examples/mcp_bot.py
+
+# Custom server URL
+python examples/mcp_bot.py --url http://localhost:8000
+
+# Verbose mode (prints every bot decision)
+python examples/mcp_bot.py --verbose
+
+# Limit turn count
+python examples/mcp_bot.py --max-turns 2000
+
+# Disable planning phase (for comparison runs)
+python examples/mcp_bot.py --no-planning
+```
+
+### Output
+
+```
+Connecting to http://localhost:8000...
+Resetting environment (launching OpenRA)...
+Discovered 48 MCP tools: ['add_to_group', 'advance', 'assign_group', ...]
+  [MCPBot] === Startup: Planning Phase ===
+...
+======================================================================
+Game finished after 2850 turns
+Result: WIN
+
+--- SCORECARD ---
+...
+
+Tools exercised: 24/48
+  ['advance', 'attack_move', 'build_structure', ...]
+======================================================================
+```
+
+---


### PR DESCRIPTION
## Problem

`mcp_bot.py` existed but had no documentation in the README. More critically, it requires `tools: disabled: []` to be uncommented in `config.yaml` for some MCP tools to be available (which are disabled in `config.py`) — without this, the bot errors on tool calls. New users had no way to know this.

## Fix

- Added a complete **MCP Bot** section to `examples/README.md`
- Documents the critical `config.yaml` prerequisite (uncomment `tools: disabled: []` and restart the server)