### PR TITLE
Expose winner and phase in get_game_state

### DIFF
--- a/openra_env/server/openra_environment.py
+++ b/openra_env/server/openra_environment.py
@@ -561,10 +561,29 @@ class OpenRAEnvironment(MCPEnvironment):
             if explored_pct == 0.0:
                 explored_pct = obs.get("explored_percent", 0.0)
 
+            game_phase = ""
+            game_winner = ""
+            game_player_count = 0
+            try:
+                bridge_state = asyncio.run_coroutine_threadsafe(
+                    env._bridge.get_state(), env._loop
+                ).result(timeout=5)
+                game_phase = getattr(bridge_state, "phase", "") or ""
+                game_winner = getattr(bridge_state, "winner", "") or ""
+                game_player_count = getattr(bridge_state, "player_count", 0) or 0
+            except Exception:
+                if obs.get("done"):
+                    game_phase = "game_over"
+
             result = {
                 "tick": obs["tick"],
                 "done": obs["done"],
                 "result": obs.get("result", ""),
+                "phase": game_phase,
+                "winner": game_winner,
+                "player_count": game_player_count,
+                "self_slot": getattr(env._config, "rl_slot", ""),
+                "enemy_slot": getattr(env._config, "ai_slot", ""),
                 "faction": getattr(env, "_player_faction", ""),
                 "economy": obs["economy"],
                 "power_balance": power_balance,

--- a/openra_env/server/openra_environment.py
+++ b/openra_env/server/openra_environment.py
@@ -575,6 +575,8 @@ class OpenRAEnvironment(MCPEnvironment):
                 if obs.get("done"):
                     game_phase = "game_over"
 
+            env_config = getattr(env, "_config", None)
+
             result = {
                 "tick": obs["tick"],
                 "done": obs["done"],
@@ -582,8 +584,8 @@ class OpenRAEnvironment(MCPEnvironment):
                 "phase": game_phase,
                 "winner": game_winner,
                 "player_count": game_player_count,
-                "self_slot": getattr(env._config, "rl_slot", ""),
-                "enemy_slot": getattr(env._config, "ai_slot", ""),
+                "self_slot": getattr(env_config, "rl_slot", ""),
+                "enemy_slot": getattr(env_config, "ai_slot", ""),
                 "faction": getattr(env, "_player_faction", ""),
                 "economy": obs["economy"],
                 "power_balance": power_balance,


### PR DESCRIPTION
## Summary                                                                                                                   
  - expose bridge `phase`, `winner`, and `player_count` from `get_game_state`                                                  
  - include `self_slot` and `enemy_slot` so clients can map the terminal result to participants                                
  - fall back to `game_over` when the observation is terminal but bridge state lookup fails                                    
                                                                                                                               
  ## Why                                                                                                                       
  `collect_bot_data.py` and other clients need an authoritative terminal game state from the bridge so data collection can stop
  on actual game over instead of running until a time limit.                                                                   
                                                                                                                               
  ## Validation                                                                                                                
  - `python -m py_compile openra_env/server/openra_environment.py`   